### PR TITLE
Replace the deprecated "dotnet new install" command

### DIFF
--- a/docs/Pages/01_01_QuickStart.md
+++ b/docs/Pages/01_01_QuickStart.md
@@ -3,7 +3,7 @@
 **Installation**
 
 ```shell
-dotnet new --install Blazor.BrowserExtension.Template
+dotnet new install Blazor.BrowserExtension.Template
 ```
 
 **Create a new project**


### PR DESCRIPTION
The `dotnet new --install` is now deprecated. .NET CLI recommends switching to `dotnet new install` instead.

![image](https://github.com/user-attachments/assets/01c69ecd-c7e3-4316-b1b4-6095bada699d)
