### PR TITLE
Upgrading to net9.0

### DIFF
--- a/src/Blazor.BrowserExtension.Build/Blazor.BrowserExtension.Build.csproj
+++ b/src/Blazor.BrowserExtension.Build/Blazor.BrowserExtension.Build.csproj
@@ -2,7 +2,7 @@
 
   <!-- Build properties. -->
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0;net472</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <IsShippingPackage>true</IsShippingPackage>

--- a/src/Blazor.BrowserExtension.Template/HelloBlazorExtension/.template.config/template.json
+++ b/src/Blazor.BrowserExtension.Template/HelloBlazorExtension/.template.config/template.json
@@ -35,10 +35,14 @@
         {
           "choice": "net8.0",
           "description": "Target .NET 8.0"
+        },
+        {
+          "choice": "net9.0",
+          "description": "Target .NET 9.0"
         }
       ],
-      "defaultValue": "net8.0",
-      "replaces": "net8.0"
+      "defaultValue": "net9.0",
+      "replaces": "net9.0"
     },
     "ManifestVersion": {
       "type": "parameter",
@@ -63,6 +67,10 @@
     "IsNet7": {
       "type": "computed",
       "value": "Framework == \"net7.0\""
+    },
+    "IsNet8": {
+      "type": "computed",
+      "value": "Framework == \"net8.0\""
     }
   },
   "sources": [

--- a/src/Blazor.BrowserExtension.Template/HelloBlazorExtension/HelloBlazorExtension.csproj
+++ b/src/Blazor.BrowserExtension.Template/HelloBlazorExtension/HelloBlazorExtension.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 <!--#if (HiddenProperties) -->
     <!-- NU1504 - Duplicate package reference. Ignore for dotnet template. -->
     <!-- NU1605 - Package reference downgrade. Ignore for dotnet template. -->
@@ -17,9 +17,12 @@
 <!--#elseif (IsNet7) -->
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.*" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.*" PrivateAssets="all" />
-<!--#else -->
+<!--#elseif (IsNet8) -->
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.*" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.*" PrivateAssets="all" />
+<!--#else -->
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.*" PrivateAssets="all" />
 <!--#endif -->
   </ItemGroup>
 

--- a/src/Blazor.BrowserExtension/Blazor.BrowserExtension.csproj
+++ b/src/Blazor.BrowserExtension/Blazor.BrowserExtension.csproj
@@ -2,7 +2,7 @@
 
   <!-- Build properties. -->
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <IsShippingPackage>true</IsShippingPackage>
@@ -44,12 +44,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Condition="'$(TargetFramework)' == 'net9.0'" Include="Microsoft.AspNetCore.Components" Version="9.0.0" />
     <PackageReference Condition="'$(TargetFramework)' == 'net8.0'" Include="Microsoft.AspNetCore.Components" Version="8.0.0" />
     <PackageReference Condition="'$(TargetFramework)' == 'net7.0'" Include="Microsoft.AspNetCore.Components" Version="7.0.0" />
     <PackageReference Condition="'$(TargetFramework)' == 'net6.0'" Include="Microsoft.AspNetCore.Components" Version="6.0.0" />
+    <PackageReference Condition="'$(TargetFramework)' == 'net9.0'" Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
     <PackageReference Condition="'$(TargetFramework)' == 'net8.0'" Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
     <PackageReference Condition="'$(TargetFramework)' == 'net7.0'" Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.0" />
     <PackageReference Condition="'$(TargetFramework)' == 'net6.0'" Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.0" />
+    <PackageReference Condition="'$(TargetFramework)' == 'net9.0'" Include="Microsoft.JSInterop" Version="9.0.0" />
     <PackageReference Condition="'$(TargetFramework)' == 'net8.0'" Include="Microsoft.JSInterop" Version="8.0.0" />
     <PackageReference Condition="'$(TargetFramework)' == 'net7.0'" Include="Microsoft.JSInterop" Version="7.0.0" />
     <PackageReference Condition="'$(TargetFramework)' == 'net6.0'" Include="Microsoft.JSInterop" Version="6.0.0" />


### PR DESCRIPTION
Just net9.0 is the latest version and should have a upgrade for most projects

And I just can't work because I need it to be dotnet 9
Also I was going to upgrade tests to 9.0 but because dotnet 9 is new so most people will not be forced to use dotnet 9 for contributing